### PR TITLE
PSYNC2 & RDB bugfix

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1582,7 +1582,10 @@ int rdbLoadRio(rio *rdb, rdbSaveInfo *rsi) {
                     (char*)auxkey->ptr,
                     (char*)auxval->ptr);
             } else if (!strcasecmp(auxkey->ptr,"repl-stream-db")) {
-                if (rsi) rsi->repl_stream_db = atoi(auxval->ptr);
+                if (rsi) {
+                    rsi->repl_stream_db = atoi(auxval->ptr);
+                    rsi->repl_stream_db_is_set = 1;
+                }
             } else if (!strcasecmp(auxkey->ptr,"repl-id")) {
                 if (rsi && sdslen(auxval->ptr) == CONFIG_RUN_ID_SIZE) {
                     memcpy(rsi->repl_id,auxval->ptr,CONFIG_RUN_ID_SIZE+1);

--- a/src/server.c
+++ b/src/server.c
@@ -3525,14 +3525,18 @@ void loadDataFromDisk(void) {
             serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
                 (float)(ustime()-start)/1000000);
 
-            /* Restore the replication ID / offset from the RDB file. */
-            if (rsi.repl_id_is_set && rsi.repl_offset != -1) {
+            /* If we are a slave, and replication ID / offset / repl-stream-db
+             * is in the RDB file, retore them
+             * and create a cached master from this information,
+             * in order to allow partial resynchronizations
+             * with masters. */
+            if (server.masterhost &&
+                rsi.repl_id_is_set && rsi.repl_offset != -1 &&
+                rsi.repl_stream_db_is_set) {
                 memcpy(server.replid,rsi.repl_id,sizeof(server.replid));
                 server.master_repl_offset = rsi.repl_offset;
-                /* If we are a slave, create a cached master from this
-                 * information, in order to allow partial resynchronizations
-                 * with masters. */
-                if (server.masterhost) replicationCacheMasterUsingMyself();
+                replicationCacheMasterUsingMyself();
+                if (rsi.repl_stream_db != -1) selectDb(server.cached_master,rsi.repl_stream_db);
             }
         } else if (errno != ENOENT) {
             serverLog(LL_WARNING,"Fatal error loading the DB: %s. Exiting.",strerror(errno));

--- a/src/server.h
+++ b/src/server.h
@@ -845,6 +845,7 @@ struct redisMemOverhead {
 typedef struct rdbSaveInfo {
     /* Used saving and loading. */
     int repl_stream_db;  /* DB to select in server.master client. */
+    int repl_stream_db_is_set;  /* True if repl_stream_db field is set. */
 
     /* Used only loading. */
     int repl_id_is_set;  /* True if repl_id field is set. */
@@ -852,7 +853,7 @@ typedef struct rdbSaveInfo {
     long long repl_offset;                  /* Replication offset. */
 } rdbSaveInfo;
 
-#define RDB_SAVE_INFO_INIT {-1,0,"000000000000000000000000000000",-1}
+#define RDB_SAVE_INFO_INIT {-1,0,0,"000000000000000000000000000000",-1}
 
 /*-----------------------------------------------------------------------------
  * Global server state

--- a/tests/integration/psync2.tcl
+++ b/tests/integration/psync2.tcl
@@ -172,7 +172,7 @@ start_server {} {
             fail "Slave not reconnecting"
         }
         set new_sync_count [status $R($master_id) sync_full]
-        assert {$sync_count == $new_sync_count}
+        assert {$sync_count != $new_sync_count}
     }
 
     if {$no_exit} {


### PR DESCRIPTION
only slave can load replication info from RDB file
and also load the repl-stream-db